### PR TITLE
Upgrade C++ projects to VS 2019, latest SDK, and C++17

### DIFF
--- a/BasicWindows/BasicWindows.vcxproj
+++ b/BasicWindows/BasicWindows.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{511A1EDC-7422-4E0D-91FE-1DE7BC191CD5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>BasicWindows</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/BasicWindows/BasicWindows.vcxproj
+++ b/BasicWindows/BasicWindows.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -91,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -106,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,6 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,6 +145,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/BasicWindows/main.cpp
+++ b/BasicWindows/main.cpp
@@ -219,17 +219,21 @@ VOID OnPaint(HWND hWnd)
     auto tmpPen = SelectObject(hDC, pen);
     auto tmpBrush = SelectObject(hDC, brush);
 
+    // draw start arrow
     MoveToEx(hDC, 60, 150, nullptr);
     LineTo(hDC, 100, 150);
     LineTo(hDC, 95, 145);
     LineTo(hDC, 95, 155);
     LineTo(hDC, 100, 150);
 
+    // draw start circle
     Ellipse(hDC, 100, 100, 200, 200);
 
+    // draw end circle
     Ellipse(hDC, 250, 100, 350, 200);
     Ellipse(hDC, 255, 105, 345, 195);
 
+    // draw arc from start to end with arrow
     MoveToEx(hDC, 150, 100, nullptr);
     SetArcDirection(hDC, AD_CLOCKWISE);
     ArcTo(hDC, 150, 75, 300, 125, 150, 100, 300, 100);
@@ -237,14 +241,17 @@ VOID OnPaint(HWND hWnd)
     LineTo(hDC, 299, 90);
     LineTo(hDC, 300, 100);
 
+    // prepare font for text
     HFONT font = CreateFont(14, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, TEXT("Consolas"));
     auto tmpFont = SelectObject(hDC, font);
 
+    // draw arc label text
     RECT rect{ 200, 50, 250, 100 };
     auto tmpBk = SetBkColor(hDC, bk);
     auto tmpClr = SetTextColor(hDC, clr);
     DrawText(hDC, L" 0, 1 ", -1, &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
 
+    // draw circles label text
     font = CreateFont(24, 0, 0, 0, FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, TEXT("Consolas"));
     SelectObject(hDC, font);
     rect = { 120, 120, 180, 180 };
@@ -255,10 +262,12 @@ VOID OnPaint(HWND hWnd)
     font = CreateFont(28, 0, 0, 0, FW_DONTCARE, FALSE, TRUE, FALSE, DEFAULT_CHARSET, OUT_OUTLINE_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, VARIABLE_PITCH, TEXT("Segoe"));
     SelectObject(hDC, font);
 
+    // draw title text
     rect = { 100, 20, 350, 50 };
     DrawText(hDC, L"Finite Automata", -1, &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
     SelectObject(hDC, tmpFont);
 
+    // reset drawing objects
     SetTextColor(hDC, tmpClr);
     SetBkColor(hDC, tmpBk);
     SelectObject(hDC, tmpPen);

--- a/BasicWindows/main.cpp
+++ b/BasicWindows/main.cpp
@@ -151,10 +151,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             break;
         }
         case WM_PAINT:
-        {
             OnPaint(hWnd);
             break;
-        }
         case WM_SIZE:
         {
             int width = LOWORD(lParam);

--- a/BasicWindows/main.cpp
+++ b/BasicWindows/main.cpp
@@ -155,10 +155,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             break;
         case WM_SIZE:
         {
-            int width = LOWORD(lParam);
-            int height = HIWORD(lParam);
+            const int width = LOWORD(lParam);
+            const int height = HIWORD(lParam);
 
-            OnSize(hWnd, wParam, width, height);
+            OnSize(hWnd, UINT(wParam), width, height);
             break;
         }
         case WM_VSCROLL:
@@ -215,7 +215,7 @@ VOID OnPaint(HWND hWnd)
     FillRect(hDC, &ps.rcPaint, brush);
 
     COLORREF clr{ 0x000079FF };
-    HPEN pen = CreatePen(PS_SOLID, 1.5, clr);
+    HPEN pen = CreatePen(PS_SOLID, 1, clr);
     auto tmpPen = SelectObject(hDC, pen);
     auto tmpBrush = SelectObject(hDC, brush);
 
@@ -258,7 +258,6 @@ VOID OnPaint(HWND hWnd)
     rect = { 100, 20, 350, 50 };
     DrawText(hDC, L"Finite Automata", -1, &rect, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
     SelectObject(hDC, tmpFont);
-
 
     SetTextColor(hDC, tmpClr);
     SetBkColor(hDC, tmpBk);

--- a/CPUsets/CPUsets.vcxproj
+++ b/CPUsets/CPUsets.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -91,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -106,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -123,6 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -142,6 +145,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/CPUsets/CPUsets.vcxproj
+++ b/CPUsets/CPUsets.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{5732E189-4575-4296-9EB3-BF4091768192}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CPUsets</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/CreateFile/CreateFile.vcxproj
+++ b/CreateFile/CreateFile.vcxproj
@@ -16,19 +16,19 @@
     <RootNamespace>CreateFile</RootNamespace>
     <IntDir>$(SolutionDir)build\$(Configuration)\$(Platform)\$(MSBuildProjectName)\obj\</IntDir>
     <OutDir>$(SolutionDir)build\$(Configuration)\$(Platform)\$(MSBuildProjectName)\bin\</OutDir>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/CreateFile/CreateFile.vcxproj
+++ b/CreateFile/CreateFile.vcxproj
@@ -59,6 +59,7 @@
       </PrecompiledHeaderFile>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -78,6 +79,7 @@
       </PrecompiledHeaderFile>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/DC-Tree/DC-Tree.vcxproj
+++ b/DC-Tree/DC-Tree.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{1AFC32CE-7DC4-4743-9800-57ECB45A9656}</ProjectGuid>
     <RootNamespace>DCTree</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <IntDir>$(SolutionDir)build\$(Configuration)\$(Platform)\$(MSBuildProjectName)\obj\</IntDir>
     <OutDir>$(SolutionDir)build\$(Configuration)\$(Platform)\$(MSBuildProjectName)\bin\</OutDir>
   </PropertyGroup>
@@ -30,26 +30,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -78,6 +78,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>
@@ -91,6 +92,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>d3d11.lib;dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -104,6 +106,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -121,6 +124,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
These eventually need to be moved to VS 2022 and the latest compiler. But, this at least will get all the projects into a stable position to make that move.

> The issue might be that the newer compiler will have new warnings or changes to the way some of the STL works, and those issues really need to be worked out on their own.